### PR TITLE
Update Shared Settings File Version (#69)

### DIFF
--- a/RadialGM.pro.shared
+++ b/RadialGM.pro.shared
@@ -3,7 +3,7 @@
 <qtcreator>
     <data>
         <variable>ProjectExplorer.Project.Updater.FileVersion</variable>
-        <value type="int">10</value>
+        <value type="int">21</value>
     </data>
     <data>
         <variable>ProjectExplorer.Project.EditorSettings</variable>


### PR DESCRIPTION
It's ok to regularly update this to the latest Qt Creator version. It stops the warning for people with the latest Qt Creator, but does not prevent people with older Qt Creator from opening the project.