### PR TITLE
Fix Main Window Settings Regression (#71)

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -128,6 +128,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     }
   });
 
+  this->readSettings();
   this->recentFiles = new RecentFiles(this, this->ui->menuRecent, this->ui->actionClearRecentMenu);
 
   ui->mdiArea->setBackground(QImage(":/banner.png"));


### PR DESCRIPTION
Restore call for the main window to read its serialized settings on construction. Insert the call after the editor diagnostics initialization so if there are any problems reading settings, that too can be logged.